### PR TITLE
fix: Broken Sword should require Excalibur

### DIFF
--- a/.spelunky2/Rules.py
+++ b/.spelunky2/Rules.py
@@ -83,6 +83,8 @@ def set_common_rules(world: "Spelunky2World", player: int):
              lambda state:
              has_royalty(world, state, player)
              and has_or_unrestricted(world, state, player, ItemName.EXCALIBUR))
+    set_rule(world.get_location(JournalName.BROKEN_SWORD),
+             lambda state: has_or_unrestricted(world, state, player, ItemName.EXCALIBUR))
     set_rule(world.get_location(JournalName.SCEPTER),
              lambda state: has_or_unrestricted(world, state, player, ItemName.SCEPTER))
     set_rule(world.get_location(JournalName.HOU_YI_BOW),


### PR DESCRIPTION
The logic for obtaining the Broken Sword Journal Entry only considers if you can reach the Tide Pools. Since the Excalibur unlock can be sent from somewhere different, the broken sword logic should consider if Excalibur is unlocked.