### PR TITLE
documentation updates

### DIFF
--- a/.spelunky2/Items.py
+++ b/.spelunky2/Items.py
@@ -21,6 +21,7 @@ quest_items = frozenset({ItemName.ALIEN_COMPASS.value, ItemName.ARROW_OF_LIGHT.v
     ItemName.TABLET_OF_DESTINY.value, ItemName.UDJAT_EYE.value, ItemName.USHABTI.value})  # noqa: E128
 
 item_options = sorted(powerup_options | equip_options)
+upgrade_items = sorted(powerup_options | equip_options | {ItemName.ALIEN_COMPASS.value})
 locked_items = sorted(powerup_options | equip_options | quest_items)
 
 character_options = frozenset({ItemName.ANA_SPELUNKY.value, ItemName.MARGARET_TUNNEL.value, ItemName.COLIN_NORTHWARD,

--- a/.spelunky2/Options.py
+++ b/.spelunky2/Options.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from Options import Toggle, DefaultOnToggle, Range, Choice, PerGameCommonOptions, DeathLink, ItemSet
 from .enums import ItemName
-from .Items import item_options, locked_items, powerup_options, equip_options, quest_items, character_options
+from .Items import item_options, upgrade_items, locked_items, powerup_options, equip_options, quest_items, character_options
 
 
 def format_options(options, row_length=10):
@@ -18,15 +18,16 @@ def format_options(options, row_length=10):
 
 
 item_options_text = format_options(sorted(item_options))
+upgrade_items_text = format_options(sorted(upgrade_items))
 locked_items_text = format_options(sorted(locked_items))
 character_options_text = format_options(sorted(character_options))
 
 
 class Goal(Choice):
     """When is your world considered finished.
-    Easy: Requires completing the "normal" ending by reaching 6-4 and defeating Tiamat
-    Hard: Requires completing the "hard" ending by reaching 7-4 and defeating Hundun
-    CO: Requires reaching a specified level in Cosmic Ocean"""
+    Easy: Requires completing the "normal" ending by reaching 6-4 and defeating Tiamat.
+    Hard: Requires completing the "hard" ending by reaching 7-4 and defeating Hundun.
+    CO: Requires reaching a specified level in Cosmic Ocean."""
     display_name = "Goal"
     option_easy = 0
     option_hard = 1
@@ -35,8 +36,8 @@ class Goal(Choice):
 
 
 class GoalLevel(Range):
-    """Which level in Cosmic Ocean are you required to clear to consider your game as beaten.
-    This option can be ignored if your goal is not set to \"CO\""""
+    '''Which level in Cosmic Ocean are you required to clear to consider your game as beaten.
+    This option is ignored if your goal is not set to "CO"'''
     display_name = "Cosmic Ocean Goal Level"
     range_start = 10
     range_end = 99
@@ -45,21 +46,23 @@ class GoalLevel(Range):
 
 class IncludeHardLocations(Toggle):
     """Include the following more problematic journal entries as locations in the AP world:
-    Magmar, Lavamander, MechSuit, Scorpion + True Crown"""
+    Magmar, Lavamander, Mech Rider, Scorpion, True Crown."""
     display_name = "Include harder journal entries"
 
 
 class ProgressiveWorlds(DefaultOnToggle):
-    """Whether new worlds should be unlocked individually or progressively."""
+    """Progresive worlds are unlocked in order: Volcana, Jungle, Olmec's Lair, Tide Pool, Temple, Ice Caves, Neo Babylon, Sunken City, Cosmic Ocean.
+    Set this to 'false' to unlock worlds individually.
+    A world can only be accessed by going through the correct doorway, which means for example if Ice Caves is not unlocked, Neo Babylon is not accessible even if it is unlocked."""
     display_name = "Progressive Worlds"
 
 
-"""
+'''
 # Not implemented yet
 class ProgressiveShortcuts(DefaultOnToggle):
-    \"""Whether new shortcuts should be unlocked individually or progressively.\"""
+    """Whether new shortcuts should be unlocked individually or progressively."""
     display_name = "Progressive Shortcuts"
-"""
+'''
 
 
 class IncreaseStartingWallet(Toggle):
@@ -132,7 +135,7 @@ class RopeUpgrades(Range):
 
 
 class RestrictedItems(ItemSet):
-    __doc__ = f"""Items that are added to the multi-world as progressive and must be found in the multi-world before they can be obtained in the game
+    __doc__ = f"""Items that must be unlocked via the multi-world before they appear in the game.
 Options: 
 {locked_items_text}"""  # noqa: E128
     display_name = "Restricted Items"
@@ -144,9 +147,9 @@ class ItemUpgrades(ItemSet):
     __doc__ = f"""Add the following useful items in the multi-world item pool which are kept on death,
 AFTER obtaining it's journal entry if 'Journal Entry Required' is true.
 Options: 
-{item_options_text}"""  # noqa: E128
+{upgrade_items_text} | """  # noqa: E128
     display_name = "Item Upgrades"
-    valid_keys = sorted(set(item_options) | {ItemName.ALIEN_COMPASS.value})
+    valid_keys = upgrade_items
     default = powerup_options - {ItemName.TRUE_CROWN.value, ItemName.EGGPLANT_CROWN.value, ItemName.PITCHERS_MITT.value}
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Spelunky 2 Archipelago Mod
 This mod allows you to connect to Archipelago in order to play a multiworld randomizer. Every journal entry is a location that you can check, and the item you send out could be anything from anyone's game, including your own. For more information about Archipelago, visit their [website](https://archipelago.gg/) or join their [Discord server](https://discord.gg/8Z65BR2).
+
 ## Features
 - Multiple game options to customize your experience, such as:
     - The goal of the run
@@ -17,23 +18,24 @@ This mod allows you to connect to Archipelago in order to play a multiworld rand
     - Checked locations and received items are unique to the Archipelago seed, allowing you to have multiple Archipelago games running at once
 
 ## Goals
-- Tiamat: Defeat Tiamat in 6-4 and complete the normal ending
-- Hundun: Defeat Hundun in 7-4 and complete the hard ending
-- Cosmic Ocean: Reach a level specified by your player options in Cosmic Ocean and complete the secret ending
+- Easy: Defeat Tiamat in 6-4 to complete the normal ending
+- Hard: Defeat Hundun in 7-4 to complete the hard ending
+- CO: Reach a level specified by your player options in Cosmic Ocean to complete the secret ending
+
+## Locations
+- Every Journal Entry is a location: Worlds, Items, Characters, Enemies, Traps
+- There's an option to exclude hard locations such as Lavamander and True Crown. You can also use the `exclude_locations` yaml field for this purpose.
+- Journal entries are logically located in an area that must be reachable. For example Plasma Cannon Journal Entry logically requires access to the Mothership; Paste Journal Entry is in Jungle; Spike Shoes Journal Entry is in Ice Caves; etc. Items with no guaranteed spawn that can be found in shops, such as Powerpack, are logically located in the Black Market. For full details, see the [source code](https://github.com/DDR-Khat/Spelunky2-Archipelago/blob/main/.spelunky2/Locations.py).
 
 ## Items
-- Rope Pile: +3 ropes for this run only
-- Bomb Bag: +3 bombs for this run only
-- Bomb Box: +12 Bombs for this run only
-- Cooked Turkey: +1 Health for this run only
-- Royal Jelly: +6 Health for this run only
-- Gold Bar: +500 gold (or more depending on the world you're in) for this run only
-- Starting Health Upgrade: +1 Health at the start of every run for each stack you have
-- Starting Bomb Increase: +1 Bomb at the start of every run for each stack you have
-- Starting Rope Increase" +1 Rope at the start of every run for each stack you have
-- Permanent Paste: Start each run with the Paste power-up
-- Progressive Compass: Start each run with either a Compass or Alien Compass depending on how many stacks you have
-- Cosmic Ocean Checkpoint: Each stack you have lets you start further into Cosmic Ocean if you die there. 1 stack will let you start at 7-10, 2 stacks at 7-20, and so on
+- World Unlock: You start with only Dwelling accessible and further worlds must be unlocked as AP items. Entering an area must be done from the correct doorway. A doorway to a locked world loops back to 1-1 or whichever other level number you started via a shortcut.
+- Rope Pile, Bomb Bag, Bomb Box, Cooked Turkey, Royal Jelly: a benefit for the current run only.
+- Gold Bar, Emerald, Sapphire, Ruby, Diamond: Some gold (scales with the world you're in) for this run only. There's an option to grant gold received through AP at the start of every run instead.
+- Starting Health/Bomb/Rope Upgrade: +1 Health/Bomb/Rope at the start of every run for each stack you have.
+- Unlock Items: Items which normally exist in Vanilla are locked until an AP item is found to unlock them. Almost every item can be locked according to your yaml: Ankh, Arrow of Light, Camera, Cape, etc.
+- Permanent Items: Start every run with an item once the AP item "Upgrade" has been found. There's an option to additionally require the Journal Entry for the item before you get it. Most items can be granted at the start of a run: Paste, Jetpack, Spike Shoes, etc.
+- Permanent Waddler Inventory: Like Permanent Items, but Waddler starts every run with the item instead of you. A larger set of items is allowed at Waddler including quest items.
+- Cosmic Ocean Checkpoint: Each stack you have lets you start further into Cosmic Ocean if you die there. 1 stack will let you start at 7-10, 2 stacks at 7-20, and so on.
 
 ## Traps
 - Poison Trap: Poisons the player


### PR DESCRIPTION
- Updates the README mentioning only Compass and Paste to be more general about unlocking items and gaining permanent upgrades.
- Adds explanations to address my confusion about world unlock order. Specifically, having only Dwelling and Sunken City unlocked does _not_ let you skip straight into Sunken City from the Dwelling exits.
- Adds some notes about the logical requirements of item journal entries.
- Other minor grammatical nits.

And this is is a bit more major:

- Fixes the displayed list of items allowed in `item_upgrades` to include `Alien Compass`.

It looks like that last one was caused by a copypaste error, but after the discussion here: https://github.com/DDR-Khat/Spelunky2-Archipelago/issues/80#issuecomment-3694041456 , it sounds like it actually should not be allowed in `item_upgrades`. Fixing that would be a code change rather than a documentation change, so I didn't do that in this PR. I can make a follow up PR to remove it from `item_upgrades` if that would be helpful.

I tested this by running `Generate Template Options` from the Launcher, and comparing the output template yamls. Here's the complete diff of the outputs:

```diff
--- before.yaml	2025-12-27 14:30:56.118420099 -0500
+++ after.yaml	2025-12-27 14:28:19.014773276 -0500
@@ -67,16 +67,16 @@
 
   goal:
     # When is your world considered finished.
-    # Easy: Requires completing the "normal" ending by reaching 6-4 and defeating Tiamat
-    # Hard: Requires completing the "hard" ending by reaching 7-4 and defeating Hundun
-    # CO: Requires reaching a specified level in Cosmic Ocean
+    # Easy: Requires completing the "normal" ending by reaching 6-4 and defeating Tiamat.
+    # Hard: Requires completing the "hard" ending by reaching 7-4 and defeating Hundun.
+    # CO: Requires reaching a specified level in Cosmic Ocean.
     easy: 50
     hard: 0
     co: 0
 
   goal_level:
     # Which level in Cosmic Ocean are you required to clear to consider your game as beaten.
-    # This option can be ignored if your goal is not set to "CO"
+    # This option is ignored if your goal is not set to "CO"
     #
     # You can define additional values between the minimum and maximum values.
     # Minimum value is 10
@@ -111,7 +111,7 @@
 
   include_hard_locations:
     # Include the following more problematic journal entries as locations in the AP world:
-    # Magmar, Lavamander, MechSuit, Scorpion + True Crown
+    # Magmar, Lavamander, Mech Rider, Scorpion, True Crown.
     'false': 50
     'true': 0
 
@@ -133,10 +133,12 @@
     # Options: 
     # - Alto Singh | Ana Spelunky | Au | Classic Guy | Coco Von Diamonds | Colin Northward | Demi Von Diamonds | Dirk Yamaoka | Guy Spelunky | Lise Project
     # - Little Jay | Liz Mutton | Manfred Tunnel | Margaret Tunnel | Nekka the Eagle | Pilot | Princess Airyn | Roffy D. Sloth | Tina Flan | Valerie Crump
-    ['Colin Northward', 'Ana Spelunky', 'Roffy D. Sloth', 'Margaret Tunnel']
+    ['Margaret Tunnel', 'Roffy D. Sloth', 'Colin Northward', 'Ana Spelunky']
 
   progressive_worlds:
-    # Whether new worlds should be unlocked individually or progressively.
+    # Progresive worlds are unlocked in order: Volcana, Jungle, Olmec's Lair, Tide Pool, Temple, Ice Caves, Neo Babylon, Sunken City, Cosmic Ocean.
+    # Set this to 'false' to unlock worlds individually.
+    # A world can only be accessed by going through the correct doorway, which means for example if Ice Caves is not unlocked, Neo Babylon is not accessible even if it is unlocked.
     'false': 0
     'true': 50
 
@@ -213,22 +215,23 @@
     random-range-0-20: 0 # random value between 0 and 20
 
   restricted_items:
-    # Items that are added to the multi-world as progressive and must be found in the multi-world before they can be obtained in the game
+    # Items that must be unlocked via the multi-world before they appear in the game.
     # Options: 
     # - Alien Compass | Ankh | Arrow of Light | Camera | Cape | Climbing Gloves | Clone Gun | Compass | Crown | Eggplant
     # - Eggplant Crown | Elixir | Excalibur | Four-Leaf Clover | Freeze Ray | Hedjet | Hou Yi's Bow | Hoverpack | Jetpack | Kapala
     # - Machete | Mattock | Paste | Pitcher's Mitt | Plasma Cannon | Powerpack | Scepter | Shield | Skeleton Key | Spectacles
     # - Spike Shoes | Spring Shoes | Tablet of Destiny | Telepack | Teleporter | True Crown | Udjat Eye | Ushabti | Vlad's Cape | Webgun
-    ['Crown', 'Udjat Eye', 'Ushabti', 'Excalibur', 'Arrow of Light', "Hou Yi's Bow", 'Tablet of Destiny', 'Scepter', 'Hedjet', 'Alien Compass']
+    ['Udjat Eye', 'Excalibur', 'Alien Compass', 'Tablet of Destiny', 'Ushabti', 'Hedjet', 'Arrow of Light', 'Crown', "Hou Yi's Bow", 'Scepter']
 
   item_upgrades:
     # Add the following useful items in the multi-world item pool which are kept on death,
     # AFTER obtaining it's journal entry if 'Journal Entry Required' is true.
     # Options: 
-    # - Ankh | Camera | Cape | Climbing Gloves | Clone Gun | Compass | Eggplant | Eggplant Crown | Elixir | Four-Leaf Clover
-    # - Freeze Ray | Hoverpack | Jetpack | Kapala | Machete | Mattock | Paste | Pitcher's Mitt | Plasma Cannon | Powerpack
-    # - Shield | Skeleton Key | Spectacles | Spike Shoes | Spring Shoes | Telepack | Teleporter | True Crown | Vlad's Cape | Webgun
-    ['Kapala', 'Four-Leaf Clover', 'Spring Shoes', 'Ankh', 'Skeleton Key', 'Climbing Gloves', 'Paste', 'Spike Shoes', 'Spectacles', 'Elixir', 'Compass']
+    # - Alien Compass | Ankh | Camera | Cape | Climbing Gloves | Clone Gun | Compass | Eggplant | Eggplant Crown | Elixir
+    # - Four-Leaf Clover | Freeze Ray | Hoverpack | Jetpack | Kapala | Machete | Mattock | Paste | Pitcher's Mitt | Plasma Cannon
+    # - Powerpack | Shield | Skeleton Key | Spectacles | Spike Shoes | Spring Shoes | Telepack | Teleporter | True Crown | Vlad's Cape
+    # - Webgun |
+    ['Compass', 'Spectacles', 'Skeleton Key', 'Paste', 'Climbing Gloves', 'Four-Leaf Clover', 'Ankh', 'Kapala', 'Spike Shoes', 'Elixir', 'Spring Shoes']
 
   waddler_upgrades:
     # Add the following useful items in the multi-world item pool which are added to Waddler's storage between runs, 
@@ -238,7 +241,7 @@
     # - Eggplant Crown | Elixir | Excalibur | Four-Leaf Clover | Freeze Ray | Hedjet | Hou Yi's Bow | Hoverpack | Jetpack | Kapala
     # - Machete | Mattock | Paste | Pitcher's Mitt | Plasma Cannon | Powerpack | Scepter | Shield | Skeleton Key | Spectacles
     # - Spike Shoes | Spring Shoes | Tablet of Destiny | Telepack | Teleporter | True Crown | Udjat Eye | Ushabti | Vlad's Cape | Webgun
-    ['Teleporter', 'Camera', 'Webgun', "Vlad's Cape", 'Clone Gun', 'Machete', 'Powerpack', 'Freeze Ray', 'Mattock', 'Plasma Cannon', 'Hoverpack', 'Jetpack', 'Cape', 'Telepack', 'Eggplant', 'Shield']
+    ['Cape', 'Shield', 'Camera', 'Webgun', 'Plasma Cannon', 'Hoverpack', 'Teleporter', "Vlad's Cape", 'Jetpack', 'Eggplant', 'Clone Gun', 'Machete', 'Telepack', 'Powerpack', 'Freeze Ray', 'Mattock']
 
   can_ankh_skip:
     # Sets if progression logic should assume you can perform Ankh skipping in Tidepool
```

Something fishy is happening where the listed options become sorted in my version of the code, for example `'Margaret Tunnel', 'Roffy D. Sloth', 'Colin Northward', 'Ana Spelunky'`. I didn't change that.

I'm investigating what's up with that. There may be something deeply wrong with my setup. One red flag is that the `__pycache__` dir is committed to version control and distributed in the `spelunky2.apworld` release, but i tested manually removing it and it's still baffling me.

Regardless of that investigation, I think this PR is an incremental improvement.