### PR TITLE
fix off by 1 error when creating cosmic ocean checkpoint items

### DIFF
--- a/.spelunky2/__init__.py
+++ b/.spelunky2/__init__.py
@@ -196,7 +196,7 @@ class Spelunky2World(World):
 
         # Cosmic Ocean checkpoints
         if self.options.goal.value == Spelunky2Goal.CO:
-            for _ in range(int(self.options.goal_level.value / 10)):
+            for _ in range(int((self.options.goal_level.value - 1) / 10)):
                 spelunky2_item_pool.append(
                     self.create_item(str(ItemName.COSMIC_OCEAN_CP))
                 )


### PR DESCRIPTION
When the goal is 7-50, there should be 4 checkpoints: 7-10, 7-20, 7-30, 7-40. The code was off by 1 dividing the goal level by 10, which would effectively generate a checkpoint for 7-50.

I tested this by generating a solo game with `goal: co` and various `goal_level:` configurations, then grepping the spoiler log for how many `: Cosmic Ocean Checkpoint` items got placed.

* `goal_level: 10` -> 0 checkpoints (1 checkpoint before this fix)
* `goal_level: 11` -> 1 checkpoint
* `goal_level: 50` -> 4 checkpoints (5 checkpoints before this fix)
* `goal_level: 51` -> 5 checkpoints

