### PR TITLE
fix: sunken city "accessible" with qilin skip regardless of world unlock

### DIFF
--- a/.spelunky2/Rules.py
+++ b/.spelunky2/Rules.py
@@ -193,13 +193,15 @@ def can_obtain_qilin(world: "Spelunky2World", state: CollectionState, player: in
 
 def can_access_sunken_city(world: "Spelunky2World", state: CollectionState, player: int) -> bool:
     return (
-            (can_obtain_qilin(world, state, player)
-            and
             (
                     state.has(WorldName.SUNKEN_CITY, player)
                     or state.has(WorldName.PROGRESSIVE, player, 6)
-            ))
-            or world.options.can_qilin_skip
+            )
+            and
+            (
+                    can_obtain_qilin(world, state, player)
+                    or world.options.can_qilin_skip
+            )
     )
 
 


### PR DESCRIPTION
If the yaml has qilin skip turned on, the logic considers sunken city to be in logic regardless of the world unlock state.

In other words, the current logic is equivalent to: (can obtain qilin `and` sunken city world state) `or` (qilin skip enabled)

The logic for sunken city should be: (sunken city `or` progressive world 6) `and` (can obtain qilin `or` qilin skip enabled)